### PR TITLE
Fixing CD-ROM functions and statusbar

### DIFF
--- a/src/WIN/win.c
+++ b/src/WIN/win.c
@@ -2489,6 +2489,7 @@ LRESULT CALLBACK StatusBarProcedure(HWND hwnd, UINT message, WPARAM wParam, LPAR
 							/* Switching from image to the same image. Do nothing. */
 							break;
 						}
+						wcscpy(cdrom_image[id].prev_image_path, cdrom_image[id].image_path);
 						cdrom_drives[id].handler->exit(id);
 						cdrom_close(id);
 						image_open(id, temp_image_path);
@@ -2511,12 +2512,13 @@ LRESULT CALLBACK StatusBarProcedure(HWND hwnd, UINT message, WPARAM wParam, LPAR
 							CheckMenuItem(sb_menu_handles[part], IDM_CDROM_EMPTY | id, MF_UNCHECKED);
 							update_status_bar_icon_state(SB_CDROM | id, 1);
 						}
+						EnableMenuItem(sb_menu_handles[part], IDM_CDROM_RELOAD | id, MF_BYCOMMAND | MF_GRAYED);
 						update_tip(SB_CDROM | id);
 						saveconfig();
 					}
 					break;
 
-	                        case IDM_CDROM_HOST_DRIVE:
+				case IDM_CDROM_HOST_DRIVE:
 					id = item_params & 0x0007;
 					letter = ((item_params >> 3) & 0x001f) + 'A';
 					part = find_status_bar_part(SB_CDROM | id);
@@ -2534,21 +2536,21 @@ LRESULT CALLBACK StatusBarProcedure(HWND hwnd, UINT message, WPARAM wParam, LPAR
 					cdrom_drives[id].prev_host_drive = cdrom_drives[id].host_drive;
 					cdrom_drives[id].handler->exit(id);
 					cdrom_close(id);
-                                	ioctl_open(id, new_cdrom_drive);
+					ioctl_open(id, new_cdrom_drive);
 					/* Signal disc change to the emulated machine. */
 					cdrom_insert(id);
-                	                CheckMenuItem(sb_menu_handles[part], IDM_CDROM_EMPTY | id, MF_UNCHECKED);
+					CheckMenuItem(sb_menu_handles[part], IDM_CDROM_EMPTY | id, MF_UNCHECKED);
 					if ((cdrom_drives[id].host_drive >= 'A') && (cdrom_drives[id].host_drive <= 'Z'))
 					{
-	                                	CheckMenuItem(sb_menu_handles[part], IDM_CDROM_HOST_DRIVE | id | ((cdrom_drives[id].host_drive - 'A') << 3), MF_UNCHECKED);
+						CheckMenuItem(sb_menu_handles[part], IDM_CDROM_HOST_DRIVE | id | ((cdrom_drives[id].host_drive - 'A') << 3), MF_UNCHECKED);
 					}
-        	                        CheckMenuItem(sb_menu_handles[part], IDM_CDROM_IMAGE | id, MF_UNCHECKED);
-                	                cdrom_drives[id].host_drive = new_cdrom_drive;
-	                                CheckMenuItem(sb_menu_handles[part], IDM_CDROM_HOST_DRIVE | id | ((cdrom_drives[id].host_drive - 'A') << 3), MF_CHECKED);
+					CheckMenuItem(sb_menu_handles[part], IDM_CDROM_IMAGE | id, MF_UNCHECKED);
+					cdrom_drives[id].host_drive = new_cdrom_drive;
+					CheckMenuItem(sb_menu_handles[part], IDM_CDROM_HOST_DRIVE | id | ((cdrom_drives[id].host_drive - 'A') << 3), MF_CHECKED);
 					EnableMenuItem(sb_menu_handles[part], IDM_CDROM_RELOAD | id, MF_BYCOMMAND | MF_GRAYED);
 					update_status_bar_icon_state(SB_CDROM | id, 0);
 					update_tip(SB_CDROM | id);
-                	                saveconfig();
+					saveconfig();
 					break;
 
 				case IDM_RDISK_EJECT:

--- a/src/WIN/win_iodev.c
+++ b/src/WIN/win_iodev.c
@@ -56,6 +56,15 @@ void cdrom_eject(uint8_t id)
 		/* Switch from empty to empty. Do nothing. */
 		return;
 	}
+	if ((cdrom_drives[id].host_drive >= 'A') && (cdrom_drives[id].host_drive <= 'Z'))
+	{
+		CheckMenuItem(sb_menu_handles[part], IDM_CDROM_HOST_DRIVE | id | ((cdrom_drives[id].host_drive - 'A') << 3), MF_UNCHECKED);
+	}
+	if (cdrom_drives[id].host_drive == 200)
+	{
+		wcscpy(cdrom_image[id].prev_image_path, cdrom_image[id].image_path);
+	}
+	cdrom_drives[id].prev_host_drive = cdrom_drives[id].host_drive;
 	cdrom_drives[id].handler->exit(id);
 	cdrom_close(id);
 	cdrom_null_open(id, 0);
@@ -65,8 +74,6 @@ void cdrom_eject(uint8_t id)
 		cdrom_insert(id);
 	}
 	CheckMenuItem(sb_menu_handles[part], IDM_CDROM_IMAGE | id, MF_UNCHECKED);
-	CheckMenuItem(sb_menu_handles[part], IDM_CDROM_HOST_DRIVE | id | ((cdrom_drives[id].host_drive - 'A') << 3), MF_UNCHECKED);
-	cdrom_drives[id].prev_host_drive = cdrom_drives[id].host_drive;
 	cdrom_drives[id].host_drive=0;
 	CheckMenuItem(sb_menu_handles[part], IDM_CDROM_EMPTY | id, MF_CHECKED);
 	update_status_bar_icon_state(SB_CDROM | id, 1);
@@ -95,6 +102,7 @@ void cdrom_reload(uint8_t id)
 	cdrom_close(id);
 	if (cdrom_drives[id].prev_host_drive == 200)
 	{
+		wcscpy(cdrom_image[id].image_path, cdrom_image[id].prev_image_path);
 		image_open(id, cdrom_image[id].image_path);
 		if (cdrom_drives[id].bus_type)
 		{

--- a/src/cdrom.h
+++ b/src/cdrom.h
@@ -162,6 +162,7 @@ typedef struct {
 	uint32_t cdrom_capacity;
 	int image_inited;
 	wchar_t image_path[1024];
+	wchar_t prev_image_path[1024];
 	FILE* image;
 	int image_changed;
 

--- a/src/config.c
+++ b/src/config.c
@@ -1654,8 +1654,9 @@ static void loadconfig_removable_devices(void)
 		}
 
 		sprintf(temps, "cdrom_%02i_image_path", c + 1);
-	        wp = config_get_wstring(cat, temps, L"");
-        	memcpy(cdrom_image[c].image_path, wp, (wcslen(wp) << 1) + 2);
+		wp = config_get_wstring(cat, temps, L"");
+		memcpy(cdrom_image[c].image_path, wp, (wcslen(wp) << 1) + 2);
+		wcscpy(cdrom_image[c].prev_image_path, cdrom_image[c].image_path);
 
 		if (cdrom_drives[c].host_drive < 'A')
 		{


### PR DESCRIPTION
fixed ejecting CD-ROM function: modified unchecking function's order before 'cdrom_null_open(id, 0);';
fixed reloading CD-ROM function: added 'prev_image_path' for reloading previous CD-ROM image.